### PR TITLE
Fix module path in go.mod and update changelog for version 1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2025-10-06
+
+### Fixed
+- Fixed module path in go.mod to include full GitHub repository path, enabling `go install github.com/berrydev-ai/gojq-mcp@latest` to work correctly
+
 ## [1.0.0] - 2025-10-06
 
 ### Added
@@ -17,5 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test suite
 - Release scripts with changelog integration
 
-[Unreleased]: https://github.com/berrydev-ai/gojq-mcp/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/berrydev-ai/gojq-mcp/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/berrydev-ai/gojq-mcp/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/berrydev-ai/gojq-mcp/releases/tag/v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module berrydev-ai/gojq-mcp
+module github.com/berrydev-ai/gojq-mcp
 
 go 1.24.4
 


### PR DESCRIPTION
Fixed module path in go.mod to include full GitHub repository path, enabling `go install github.com/berrydev-ai/gojq-mcp@latest` to work correctly