### PR TITLE
Add HTTP and SSE transport support with enhanced CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2] - 2025-10-06
+
+### Added
+- HTTP transport support via `-t http` flag for web-based MCP integrations
+- SSE (Server-Sent Events) transport support via `-t sse` flag for event-driven clients
+- Transport selection flag `-t` with support for stdio (default), http, and sse transports
+- Address flag `-a` for configuring listening address for http/sse transports (default: :8080)
+- `--help` and `-h` flags to display comprehensive usage information
+- `--version` flag to display version information
+- Makefile targets for running different transports: `run-http`, `run-http-custom`, `run-sse`, `run-sse-custom`
+
+### Changed
+- Enhanced CLI with better help output showing all available modes, options, and examples
+- Server startup now displays informative messages indicating transport type and listening address
+
 ## [1.0.1] - 2025-10-06
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean test install
+.PHONY: build clean test install run-cli run-build run-inspector run-server run-http run-http-custom run-sse run-sse-custom
 
 BINARY_NAME=gojq-mcp
 BUILD_DIR=dist
@@ -27,3 +27,15 @@ run-inspector: build
 
 run-server:
 	go run .
+
+run-http:
+	go run . -t http
+
+run-http-custom:
+	go run . -t http -a :9000
+
+run-sse:
+	go run . -t sse
+
+run-sse-custom:
+	go run . -t sse -a :9000

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-const version = "1.0.1"
+const version = "1.0.2"
 
 func printUsage() {
 	fmt.Fprintf(os.Stderr, `gojq-mcp v%s - A dual-mode JSON query tool

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ EXAMPLES:
 
   # Server mode - SSE transport
   gojq-mcp -t sse
-  gojq-mcp -t sse -a localhost:8080
+  gojq-mcp -t sse -a :8080
 
 DOCUMENTATION:
   https://github.com/berrydev-ai/gojq-mcp


### PR DESCRIPTION
This commit introduces multiple transport options for the MCP server
and improves the command-line interface with comprehensive help output.

New Features:
- HTTP transport support via StreamableHTTPServer for web-based integrations
- SSE (Server-Sent Events) transport support via NewSSEServer for event-driven clients
- Transport selection flag (-t) supporting stdio (default), http, and sse
- Address configuration flag (-a) for http/sse transports (default: :8080)
- Help flags (--help, -h) displaying comprehensive usage information
- Version flag (--version) showing current version
- Makefile targets: run-http, run-http-custom, run-sse, run-sse-custom

Improvements:
- Enhanced CLI with clear sections for usage, modes, options, and examples
- Informative server startup messages showing transport type and address
- Better error handling for invalid transport types

The server now defaults to stdio transport for backward compatibility,
while supporting HTTP and SSE for different integration scenarios.

Updated CHANGELOG.md with all new features and changes.